### PR TITLE
Add registry spaces in stack config, including selfhosted space

### DIFF
--- a/config/cozy.yaml
+++ b/config/cozy.yaml
@@ -9,4 +9,8 @@ couchdb:
 log:
   level: debug 
   syslog: false
-
+registries:
+  default:
+  - https://apps-registry.cozycloud.cc/selfhosted
+  - https://apps-registry.cozycloud.cc/banks
+  - https://apps-registry.cozycloud.cc/


### PR DESCRIPTION
Add registry spaces to stack config, including selfhosted space to benefit from selfhosted specific apps and konnectors